### PR TITLE
vanity: add keywords to title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Snail
+# Snail: CLI for Glitch
 
 [![npm](https://img.shields.io/npm/v/glitch-snail)](https://www.npmjs.com/package/glitch-snail)
 [![npm](https://img.shields.io/npm/dt/glitch-snail?label=downloads%20%28npm%29)](https://www.npmjs.com/package/glitch-snail)
 [![GitHub releases](https://img.shields.io/github/downloads/wh0/snail-cli/total?label=downloads%20%28GitHub%29)](https://github.com/wh0/snail-cli/releases)
 
-Snail is a CLI for Glitch.
+Snail is a command line tool for Glitch.
 See our [website](https://snail-cli.glitch.me) for instructions and stuff.

--- a/vanity/index.html
+++ b/vanity/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Snail</title>
+<title>Snail: CLI for Glitch</title>
 <script>
   if (window.location.protocol === 'http:' && !window.isSecureContext) {
     const httpsUrl = new URL(window.location.href);
@@ -18,7 +18,7 @@
 <link rel="icon" href="snail.svg">
 <link rel="canonical" href="https://snail-cli.glitch.me/">
 <meta name="description" content="We're making our own command line tool for Glitch, and it's called Snail.">
-<meta property="og:title" content="Snail">
+<meta property="og:title" content="Snail: CLI for Glitch">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://cdn.glitch.com/61580a7e-b0da-49f9-848d-000e8dd4af75%2Fsnail-cli-og.jpg?v=1629519357467">
 <meta property="og:url" content="https://snail-cli.glitch.me/">


### PR DESCRIPTION
I want to show up in searches for "glitch cli." not really sure how, but I haven't been using "CLI" much. so let's at least put that in the title

in everything else, I've been calling it a "command line tool." \\: