### PR TITLE
practice: escape greater than sign

### DIFF
--- a/vanity/practice/index.html
+++ b/vanity/practice/index.html
@@ -611,7 +611,7 @@ ls -al .data
         Make a file that we'll upload:
       </p>
 <pre class="sigil sigil-command">
-git config user.name >/tmp/me.html
+git config user.name &gt;/tmp/me.html
 </pre>
       <p>
         Snail hasn't settled on a best way to transfer files, but the <code>rsync</code> wrapper is pretty friendly.


### PR DESCRIPTION
most of them are entered as `&gt;`, I think this one not being escaped is a mistake